### PR TITLE
fix: remove `clientVer`, add `key`, `buvid` in WSOptions

### DIFF
--- a/src/base/base.ts
+++ b/src/base/base.ts
@@ -71,11 +71,12 @@ export class LiveClient<E extends Record<EventKey, any>> extends EventEmitter<Me
 
     this.firstMessage = {
       roomid: room,
-      clientver: options.clientVer,
       protover: options.protover,
       uid: options.uid,
       platform: options.platform,
       type: options.type,
+      key: options.key,
+      buvid: options.buvid,
     }
 
     if (options.key)

--- a/src/base/types.ts
+++ b/src/base/types.ts
@@ -125,23 +125,24 @@ export interface ConnectionOptions {
 
 export interface WSOptions extends BaseOptions, AuthOptions, ConnectionOptions {
   ssl?: boolean
-  clientVer?: `${number}.${number}.${number}` | `${number}.${number}.${number}.${number}`
-  platform?: 'web'
+  platform?: 'web' | string
   protover?: 1 | 2 | 3
   uid?: number
   type?: number
+  key?: string
+  buvid?: string
 }
 
 export interface TCPOptions extends WSOptions {}
 
 export interface LiveHelloMessage {
-  clientver?: `${number}.${number}.${number}` | `${number}.${number}.${number}.${number}`
-  platform?: 'web'
+  platform?: 'web' | string
   protover?: 1 | 2 | 3
   roomid: number
   uid?: number
   type?: number
-  key?: any
+  key?: string
+  buvid?: string
 }
 
 export interface MessageMeta extends ProtocolHeader {}


### PR DESCRIPTION
relate issue: https://github.com/ddiu8081/blive-message-listener/issues/29

鉴于用户名打码问题看了下目前的解决方案，修改建立连接的请求参数：

1. uid + platform，platform 需要非 `web`
2. uid + key + buvid

且根据 https://github.com/simon300000/bilibili-live-ws/issues/397#issuecomment-1617901764 似乎也不再需要 `clientver` 了

所以整体修改了下传值逻辑还有类型声明